### PR TITLE
Remote Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Thinktecture.IdentityManager
 ============================
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/thinktecture/Thinktecture.IdentityManager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/IdentityManager/Thinktecture.IdentityManager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 **current status: beta 2**
 
@@ -8,4 +8,4 @@ Thinktecture.IdentityManager
 
 IdentityManager is a tool for developers and/or administrators to manage the identity information for users of their applications. This includes creating users, editing user information (passwords, email, claims, etc.) and deleting users. It provides a modern replacement for the ASP.NET WebSite Administration tool that used to be built into Visual Studio.
 
-Documentation and more information can be found on the [wiki](https://github.com/thinktecture/Thinktecture.IdentityManager/wiki).
+Documentation and more information can be found on the [wiki](https://github.com/IdentityManager/Thinktecture.IdentityManager/wiki).

--- a/source/Core/Configuration/AppBuilderExtensions.cs
+++ b/source/Core/Configuration/AppBuilderExtensions.cs
@@ -28,6 +28,7 @@ using Thinktecture.IdentityManager.Configuration;
 using Thinktecture.IdentityManager.Configuration.Hosting;
 using Thinktecture.IdentityManager.Configuration.Hosting.LocalAuthenticationMiddleware;
 using Thinktecture.IdentityModel.Owin.ScopeValidation;
+using Thinktecture.IdentityManager.Configuration.Hosting.RemoteAuthenticationMiddleware;
 
 namespace Owin
 {
@@ -49,6 +50,11 @@ namespace Owin
                 var local = new LocalAuthenticationOptions(options.AdminRoleName);
                 app.Use<LocalAuthenticationMiddleware>(local);
             }
+			else if(options.SecurityMode == SecurityMode.LocalAndRemote)
+			{
+			    var remote = new RemoteAuthenticationOptions(options.AdminRoleName);
+			    app.Use<RemoteAuthenticationMiddleware>(remote);
+			}
             else if (options.SecurityMode == SecurityMode.OAuth2)
             {
                 var jwtParams = new System.IdentityModel.Tokens.TokenValidationParameters

--- a/source/Core/Configuration/Hosting/RemoteAuthenticationMiddleware/RemoteAuthenticationHandler.cs
+++ b/source/Core/Configuration/Hosting/RemoteAuthenticationMiddleware/RemoteAuthenticationHandler.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright 2014 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Infrastructure;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Thinktecture.IdentityManager.Resources;
+
+namespace Thinktecture.IdentityManager.Configuration.Hosting.RemoteAuthenticationMiddleware
+	{
+	public class RemoteAuthenticationHandler : AuthenticationHandler<RemoteAuthenticationOptions>
+		{
+		protected override Task<Microsoft.Owin.Security.AuthenticationTicket> AuthenticateCoreAsync()
+			{
+			var id = new ClaimsIdentity(Constants.RemoteAuthenticationType, Constants.ClaimTypes.Name, Constants.ClaimTypes.Role);
+			id.AddClaim(new Claim(Constants.ClaimTypes.Name, Messages.LocalUsername));
+			id.AddClaim(new Claim(Constants.ClaimTypes.Role, this.Options.RoleToAssign));
+
+			var ticket = new AuthenticationTicket(id, new AuthenticationProperties());
+			return Task.FromResult(ticket);
+			}
+		}
+	}

--- a/source/Core/Configuration/Hosting/RemoteAuthenticationMiddleware/RemoteAuthenticationMiddleware.cs
+++ b/source/Core/Configuration/Hosting/RemoteAuthenticationMiddleware/RemoteAuthenticationMiddleware.cs
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-namespace Thinktecture.IdentityManager.Configuration
-{
-    public enum SecurityMode
-    {
-        LocalMachine,
-        OAuth2,
-		LocalAndRemote
-    }
-}
+
+using Microsoft.Owin;
+using Microsoft.Owin.Security.Infrastructure;
+
+namespace Thinktecture.IdentityManager.Configuration.Hosting.RemoteAuthenticationMiddleware
+	{
+	public class RemoteAuthenticationMiddleware : AuthenticationMiddleware<RemoteAuthenticationOptions>
+		{
+		public RemoteAuthenticationMiddleware(OwinMiddleware next, RemoteAuthenticationOptions options)
+			: base(next, options)
+			{
+			}
+
+		protected override AuthenticationHandler<RemoteAuthenticationOptions> CreateHandler()
+			{
+			return new RemoteAuthenticationHandler();
+			}
+		}
+	}

--- a/source/Core/Configuration/Hosting/RemoteAuthenticationMiddleware/RemoteAuthenticationOptions.cs
+++ b/source/Core/Configuration/Hosting/RemoteAuthenticationMiddleware/RemoteAuthenticationOptions.cs
@@ -13,13 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-namespace Thinktecture.IdentityManager.Configuration
-{
-    public enum SecurityMode
-    {
-        LocalMachine,
-        OAuth2,
-		LocalAndRemote
-    }
-}
+
+using Microsoft.Owin.Security;
+
+namespace Thinktecture.IdentityManager.Configuration.Hosting.RemoteAuthenticationMiddleware
+	{
+	public class RemoteAuthenticationOptions : AuthenticationOptions
+		{
+		public RemoteAuthenticationOptions(string roleToAssign)
+			: base(Constants.RemoteAuthenticationType)
+			{
+			this.RoleToAssign = roleToAssign;
+			}
+
+		public string RoleToAssign { get; private set; }
+		}
+	}

--- a/source/Core/Configuration/WebApiConfig.cs
+++ b/source/Core/Configuration/WebApiConfig.cs
@@ -47,6 +47,10 @@ namespace Thinktecture.IdentityManager.Configuration
             {
                 config.Filters.Add(new HostAuthenticationAttribute(Constants.LocalAuthenticationType));
             }
+			else if (options.SecurityMode == SecurityMode.LocalAndRemote)
+			{
+			    config.Filters.Add(new HostAuthenticationAttribute(Constants.RemoteAuthenticationType));
+			}
             else
             {
                 config.Filters.Add(new HostAuthenticationAttribute(Constants.BearerAuthenticationType));

--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -19,6 +19,7 @@ namespace Thinktecture.IdentityManager
     public class Constants
     {
         public const string LocalAuthenticationType = "idmgr.local";
+		public const string RemoteAuthenticationType = "idmgr.remote";
         public const string BearerAuthenticationType = "Bearer";
 
         public const string IdMgrScope = "idmgr";

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -147,6 +147,9 @@
     <Compile Include="Configuration\Hosting\LocalAuthenticationMiddleware\LocalAuthenticationMiddleware.cs" />
     <Compile Include="Configuration\Hosting\LocalAuthenticationMiddleware\LocalAuthenticationOptions.cs" />
     <Compile Include="Configuration\Hosting\LogProviderExceptionLogger.cs" />
+    <Compile Include="Configuration\Hosting\RemoteAuthenticationMiddleware\RemoteAuthenticationHandler.cs" />
+    <Compile Include="Configuration\Hosting\RemoteAuthenticationMiddleware\RemoteAuthenticationMiddleware.cs" />
+    <Compile Include="Configuration\Hosting\RemoteAuthenticationMiddleware\RemoteAuthenticationOptions.cs" />
     <Compile Include="Configuration\Hosting\TraceLogger.cs" />
     <Compile Include="Configuration\IdentityManagerServiceFactory.cs" />
     <Compile Include="Configuration\IDependencyResolver.cs" />
@@ -253,7 +256,9 @@
     </EmbeddedResource>
     <None Include="app.config" />
     <None Include="Assets\Scripts\Frame.js.bundle" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="..\default.licenseheader">
       <Link>default.licenseheader</Link>
     </None>

--- a/source/Host/Host.csproj
+++ b/source/Host/Host.csproj
@@ -74,6 +74,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Thinktecture.IdentityServer.v3.1.0.0-pre-10111\lib\net45\Thinktecture.IdentityServer.dll</HintPath>
     </Reference>
+    <Reference Include="Thinktecture.IdentityServer3">
+      <HintPath>..\packages\Thinktecture.IdentityServer3.1.1.0\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\default.licenseheader">

--- a/source/Host/IdSvr/IdSvrConfig.cs
+++ b/source/Host/IdSvr/IdSvrConfig.cs
@@ -39,7 +39,7 @@ namespace Thinktecture.IdentityManager.Host.IdSvr
                 Endpoints = new EndpointOptions {
                     EnableCspReportEndpoint = true
                 },
-                PublicHostName = "http://localhost:17457",
+                //PublicHostName = "http://localhost:17457",
                 RequireSsl = false,
                 Factory = factory,
                 CorsPolicy = CorsPolicy.AllowAll,

--- a/source/Host/Web.config
+++ b/source/Host/Web.config
@@ -55,7 +55,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />

--- a/source/Host/packages.config
+++ b/source/Host/packages.config
@@ -3,5 +3,7 @@
   <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.0" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net451" />
-  <package id="Thinktecture.IdentityServer.v3" version="1.0.0-pre-10111" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3" version="1.1.0" targetFramework="net45" />
+  <!-- Can't find below package. Using public one... -->
+  <!-- <package id="Thinktecture.IdentityServer.v3" version="1.0.0-pre-10111" targetFramework="net45" /> -->
 </packages>


### PR DESCRIPTION
Added remote middleware so that IDM can be used remotely without needing to configure OAuth. The idea is that people will secure it by other means, such as modifying their web.config with a location element and specifying certain roles to access it.

    <configuration>
      <location path="idm">
        <system.web>
          <authorization>
            <allow roles="Admin" />
            <deny users="*" />
          </authorization>
        </system.web>
      </location>
    </configuration>

The new mode is activated by passing the `SecurityMode.LocalAndRemote` option when setting the `IdentityManagerOptions`.