### PR TITLE
Switched Host project to use the latest version of IdentityServer3

### DIFF
--- a/source/Host/Host.csproj
+++ b/source/Host/Host.csproj
@@ -22,6 +22,7 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,6 +42,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IdentityServer3, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.0.1\lib\net45\IdentityServer3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
@@ -92,10 +97,6 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Thinktecture.IdentityServer3, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Thinktecture.IdentityServer3.1.4.1\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\default.licenseheader">

--- a/source/Host/Startup.cs
+++ b/source/Host/Startup.cs
@@ -31,8 +31,8 @@ using System.Threading.Tasks;
 using System.IdentityModel.Tokens;
 using Microsoft.Owin.Security.Cookies;
 
-[assembly: OwinStartup(typeof(StartupWithLocalhostSecurity))]
-//[assembly: OwinStartup(typeof(StartupWithHostCookiesSecurity))]
+//[assembly: OwinStartup(typeof(StartupWithLocalhostSecurity))]
+[assembly: OwinStartup(typeof(StartupWithHostCookiesSecurity))]
 
 namespace IdentityManager.Host
 {

--- a/source/Host/packages.config
+++ b/source/Host/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="IdentityServer3" version="2.0.1" targetFramework="net45" />
   <package id="LibLog" version="4.2.1" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
@@ -9,5 +10,4 @@
   <package id="Microsoft.Owin.Security.OpenIdConnect" version="3.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net451" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.202250711" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3" version="1.4.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I was struggling with why the Host Config in the sample implementation would not work for me in my current project using IdentityServer3. Once we discovered that the latest version of IdentityServer3 requires that Clients state their AllowedScopes we solved the issue. 
I thought we should contribute this back.

Added the AllowedScopes to the client for idmgr, 
Changed the InMemoryFactory to use a CorsSecurityPoilicy

Removed the Loging from IdentityServer as the IdentityManager implementation is not compatible as yet.
