### PR TITLE
Soft-remove VisualStudioVersion 

### DIFF
--- a/source/Host/Host.csproj
+++ b/source/Host/Host.csproj
@@ -136,7 +136,7 @@
       <Name>Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="false">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>


### PR DESCRIPTION
block that references VS2010 when building with psake.

I used a soft remove for test purposes, it appears this can Just Be Removed if VS2010 builds aren't a desired target any more. 

