### PR TITLE
Updated AutoMapper to 4.2.0 and removed static api mappings

### DIFF
--- a/source/Core/Api/Models/RoleQueryResultResource.cs
+++ b/source/Core/Api/Models/RoleQueryResultResource.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Web.Http.Routing;
+using AutoMapper;
 
 namespace IdentityManager.Api.Models
 {
@@ -44,12 +45,16 @@ namespace IdentityManager.Api.Models
 
     public class RoleQueryResultResourceData : QueryResult<RoleSummary>
     {
+        public static IMapper Mapper { get; set; }
         static RoleQueryResultResourceData()
         {
-            AutoMapper.Mapper.CreateMap<QueryResult<RoleSummary>, RoleQueryResultResourceData>()
-                .ForMember(x => x.Items, opts => opts.MapFrom(x => x.Items));
-            AutoMapper.Mapper.CreateMap<RoleSummary, RoleResultResource>()
-                .ForMember(x => x.Data, opts => opts.MapFrom(x => x));
+            Mapper = new MapperConfiguration(config =>
+            {
+                config.CreateMap<QueryResult<RoleSummary>, RoleQueryResultResourceData>()
+                    .ForMember(x => x.Items, opts => opts.MapFrom(x => x.Items));
+                config.CreateMap<RoleSummary, RoleResultResource>()
+                    .ForMember(x => x.Data, opts => opts.MapFrom(x => x));
+            }).CreateMapper();
         }
 
         public RoleQueryResultResourceData(QueryResult<RoleSummary> result, UrlHelper url, RoleMetadata meta)
@@ -58,7 +63,7 @@ namespace IdentityManager.Api.Models
             if (url == null) throw new ArgumentNullException("url");
             if (meta == null) throw new ArgumentNullException("meta");
 
-            AutoMapper.Mapper.Map(result, this);
+            Mapper.Map(result, this);
 
             foreach (var role in this.Items)
             {

--- a/source/Core/Api/Models/UserQueryResultResource.cs
+++ b/source/Core/Api/Models/UserQueryResultResource.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Web.Http.Routing;
+using AutoMapper;
 
 namespace IdentityManager.Api.Models
 {
@@ -44,12 +45,16 @@ namespace IdentityManager.Api.Models
 
     public class UserQueryResultResourceData : QueryResult<UserSummary>
     {
+        public static IMapper Mapper { get; set; }
         static UserQueryResultResourceData()
         {
-            AutoMapper.Mapper.CreateMap<QueryResult<UserSummary>, UserQueryResultResourceData>()
-                .ForMember(x => x.Items, opts => opts.MapFrom(x => x.Items));
-            AutoMapper.Mapper.CreateMap<UserSummary, UserResultResource>()
-                .ForMember(x => x.Data, opts => opts.MapFrom(x => x));
+            Mapper = new MapperConfiguration(config =>
+            {
+                config.CreateMap<QueryResult<UserSummary>, UserQueryResultResourceData>()
+                    .ForMember(x => x.Items, opts => opts.MapFrom(x => x.Items));
+                config.CreateMap<UserSummary, UserResultResource>()
+                    .ForMember(x => x.Data, opts => opts.MapFrom(x => x));
+            }).CreateMapper();
         }
 
         public UserQueryResultResourceData(QueryResult<UserSummary> result, UrlHelper url, UserMetadata meta)
@@ -58,7 +63,7 @@ namespace IdentityManager.Api.Models
             if (url == null) throw new ArgumentNullException("url");
             if (meta == null) throw new ArgumentNullException("meta");
 
-            AutoMapper.Mapper.Map(result, this);
+            Mapper.Map(result, this);
 
             foreach (var user in this.Items)
             {

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -41,12 +41,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="AutoMapper, Version=3.3.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="AutoMapper.Net4, Version=3.3.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.Net4.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -325,7 +321,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/Core/packages.config
+++ b/source/Core/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
-  <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="ilmerge" version="2.14.1208" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
Updated AutoMapper to version 4.2.0 to support new versions of AutoMapper.
- Updated mapper in RoleQueryResultResourceData
- Updated mapper in UserQueryResultResourceData

#257 